### PR TITLE
Fix sequence export file

### DIFF
--- a/04_import_dvdrental_pg1.sh
+++ b/04_import_dvdrental_pg1.sh
@@ -8,6 +8,6 @@ pg_restore -h localhost -U app -d app -p 5432 -O dvdrental.tar
 # Export sequences id
 echo "Export sequences id's"
 rm sequences.txt
-kubectl exec -it pg1-1 -- psql app -t -c "select 'select setval(''' || sequencename ||''',' || last_value||');' from pg_sequences;" > sequences.txt
+kubectl exec -it pg1-1 -- psql app -t -c "select 'select setval(''' || sequencename ||''',' || last_value||');' from pg_sequences;" > sequences.sql
 kubectl exec -it pg1-1 -- psql app -c "\d"
 


### PR DESCRIPTION
The sequences were exported to sequences.txt and later imported from sequences.sql, which doesn't work for obvious reasons.

This commit renames the export file to sequences.sql, so they can be imported from there successfully later.